### PR TITLE
#eventually_expect

### DIFF
--- a/lib/eventually_helper.rb
+++ b/lib/eventually_helper.rb
@@ -15,4 +15,9 @@ module EventuallyHelper
       sleep interval
     end
   end
+
+  def eventually_expect &assertion
+    eventually{raise unless assertion.call}
+    expect(assertion.call)
+  end
 end

--- a/lib/eventually_helper.rb
+++ b/lib/eventually_helper.rb
@@ -16,8 +16,8 @@ module EventuallyHelper
     end
   end
 
-  def eventually_expect &assertion
-    eventually{raise unless assertion.call}
+  def eventually_expect(&assertion)
+    eventually { raise unless assertion.call }
     expect(assertion.call)
   end
 end

--- a/spec/eventually_spec.rb
+++ b/spec/eventually_spec.rb
@@ -11,12 +11,12 @@ describe 'EventuallyHelper' do
   end
 
   it 'can attach to expect statements' do
-    @test = ->{
+    @test = lambda do
       responses = %w(duck duck goose goose).cycle
-      ->{ responses.next }
-    }.call
+      -> { responses.next }
+    end.call
     outcome = 'goose'
 
-    eventually_expect{ @test.call == outcome }.to be true
+    eventually_expect { @test.call == outcome }.to be true
   end
 end

--- a/spec/eventually_spec.rb
+++ b/spec/eventually_spec.rb
@@ -9,4 +9,14 @@ describe 'EventuallyHelper' do
     eventually { @test = outcome }
     expect(@test).to eq outcome
   end
+
+  it 'can attach to expect statements' do
+    @test = ->{
+      responses = %w(duck duck goose goose).cycle
+      ->{ responses.next }
+    }.call
+    outcome = 'goose'
+
+    eventually_expect{ @test.call == outcome }.to be true
+  end
 end


### PR DESCRIPTION
When the assertion and the wait statements are identical, instead a call to `eventually` and then a call to `expect` with the same statement, now you can use `eventually_expect`, i.e. 

``` ruby
eventually_expect{ @test.call == outcome }.to be true
```

N.B. the assertion should be a boolean expression
